### PR TITLE
Remove console.warn

### DIFF
--- a/src/aggro.js
+++ b/src/aggro.js
@@ -179,9 +179,6 @@
             test: test
           });
         }
-        else {
-          console.warn( 'Aggro.filter was called without any filter created!' );
-        }
       }
       return aggro;
     };


### PR DESCRIPTION
If I understand correctly, calling `Aggro.filter` without any filters is technically supported and in certain use cases exactly what you want to do, hence I wanted to suggest removing this warning, since it just pollutes the console and is visible in production as well.

The alternative would be to only display it in dev environments, which would require some way of letting `aggro` know that it is running in such an environment.